### PR TITLE
feat(member): update Marco's profile with latest achievements and academic status

### DIFF
--- a/src/member/2024/Marco.tsx
+++ b/src/member/2024/Marco.tsx
@@ -341,7 +341,7 @@ export const MarcoMemberPage = () => {
             zhName="黃昱翔"
             enName="Marco"
             avatar={logo}
-            institutes={["國立臺北科技大學 資訊安全碩士學位學程 碩一"]}
+            institutes={["國立臺北科技大學 資訊安全碩士學位學程 碩二"]}
             bio={bio}
             experiences={raceExperiences}
             certificates={certificates}

--- a/src/member/2024/Marco.tsx
+++ b/src/member/2024/Marco.tsx
@@ -15,6 +15,16 @@ export const MarcoMemberPage = () => {
     ]
     const raceExperiences: MemberCompetitionExperienceType[] = [
         {
+            title: "InfoSec Taiwan CTF 2025 / 隊名：Archetype",
+            result: "第 26 名（48%）",
+            datetime: "2025"
+        },
+        {
+            title: "Hack The Tainan - 紅藍軍攻防資安競賽 / 隊名：高端的注入攻擊",
+            result: "第 8 名（32%）",
+            datetime: "2025"
+        },
+        {
             title: "AIS3 EOF CTF 進階資安攻防演練 / 隊名：隊名為 20 個字元以內",
             result: "第 7 名（63%）",
             datetime: "2025"
@@ -66,6 +76,10 @@ export const MarcoMemberPage = () => {
         }
     ]
     const participates: MemberParticipateType[] = [
+    {
+        "title": "教育部資訊及科技教育司 - 114年度教育體系資安攻防演練 攻防檢測員",
+        "datetime": "2025"
+    },
     {
         "title": "國家資通安全研究院 - 網路攻防演練 攻擊手",
         "datetime": "2025"

--- a/src/member/2024/Marco.tsx
+++ b/src/member/2024/Marco.tsx
@@ -123,7 +123,7 @@ export const MarcoMemberPage = () => {
     const internExperiences: MemberInternType[] = [
         {
             company: "AIFT (OneDegree)",
-            info: "Security Research Engineering Intern, Cymetrics",
+            info: "Security Engineering Intern, Cymetrics",
             datetime: "2025.03 - Present",
         },
     ]


### PR DESCRIPTION
## 📝 Summary
Update Marco's member profile with latest security competitions, internship position, activities, and correct academic information.

## 🚀 Changes Made
### ✅ Internship & Academic Updates
- Update internship position to **AIFT (OneDegree)** - Security Engineering Intern, Cymetrics  
- Correct academic year from 碩一 to **碩二** (M1 → M2)

### 🏆 New Competition Results
- **InfoSec Taiwan CTF 2025** (26th place, 48%) - Team: Archetype
- **Hack The Tainan 紅藍軍攻防資安競賽** (8th place, 32%) - Team: 高端的注入攻擊

### 🎯 New Activities
- Added participation in **教育部資訊及科技教育司 - 114年度教育體系資安攻防演練** as penetration tester

## 📊 Impact
- ✅ Keeps Marco's profile current with 2025 achievements
- ✅ Reflects accurate academic and professional status  
- ✅ Maintains timeline consistency across all entries

## 📋 Commits Included
- `feat(member): update Marco's internship position to AIFT (OneDegree)`
- `feat(member): add Marco's latest CTF competitions and security activities`  
- `fix(member): update Marco's academic year from M1 to M2`